### PR TITLE
Added Confirmation page, and page helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ return GovukPage::summary(...);
 return GovukPage::tasklist(...);
 ```
 
+#### Confirm Page
+
+Show a confirmation page with a confirm and back button, with additional context via a content blade.
+
 ### Building custom pages
 
 ```php

--- a/src/app/Helpers/GovukPage.php
+++ b/src/app/Helpers/GovukPage.php
@@ -2,6 +2,7 @@
 
 namespace AnthonyEdmonds\GovukLaravel\Helpers;
 
+use AnthonyEdmonds\GovukLaravel\Pages\Page;
 use Illuminate\Contracts\View\View;
 
 class GovukPage
@@ -11,9 +12,27 @@ class GovukPage
         // TODO
     }
 
-    public static function confirm(): View
+    public static function confirm(
+        string $title,
+        string $contentBlade,
+        string $backRoute,
+        string $actionRoute,
+        string $buttonLabel,
+        string $method = 'post',
+        string $buttonType = Page::NORMAL_BUTTON,
+        string $caption = null
+    ): View
     {
-        // TODO
+        return Page::create($title)
+            ->setAction($actionRoute)
+            ->setBack($backRoute)
+            ->setButtonLabel($buttonLabel)
+            ->setButtonType($buttonType)
+            ->setCaption($caption)
+            ->setContent($contentBlade)
+            ->setMethod($method)
+            ->setTemplate('confirm')
+            ->toView();
     }
     
     public static function custom(): View

--- a/src/app/Helpers/GovukPage.php
+++ b/src/app/Helpers/GovukPage.php
@@ -15,9 +15,9 @@ class GovukPage
     public static function confirm(
         string $title,
         string $contentBlade,
-        string $backRoute,
-        string $actionRoute,
         string $buttonLabel,
+        string $actionRoute,
+        string $backRoute,
         string $method = 'post',
         string $buttonType = Page::NORMAL_BUTTON,
         string $caption = null

--- a/src/app/Pages/Page.php
+++ b/src/app/Pages/Page.php
@@ -140,6 +140,6 @@ class Page
     
     public function toView(): View
     {
-        return view("templates::{$this->template}", $this->toArray());
+        return view("govuk::templates.{$this->template}", $this->toArray());
     }
 }

--- a/src/app/Pages/Page.php
+++ b/src/app/Pages/Page.php
@@ -2,7 +2,142 @@
 
 namespace AnthonyEdmonds\GovukLaravel\Pages;
 
+use Illuminate\Contracts\View\View;
+
 class Page
 {
-    // TODO
+    const BUTTON_TYPES = [
+        self::NORMAL_BUTTON,
+        self::SECONDARY_BUTTON,
+        self::START_BUTTON,
+        self::WARNING_BUTTON,
+    ];
+    const NORMAL_BUTTON = '';
+    const SECONDARY_BUTTON = 'secondary';
+    const START_BUTTON = 'start';
+    const WARNING_BUTTON = 'warning';
+    
+    protected ?string $action = null;
+    protected ?string $back = null;
+    protected ?array $breadcrumbs = null;
+    protected ?string $buttonLabel = null;
+    protected string $buttonType = self::NORMAL_BUTTON;
+    protected ?string $caption = null;
+    protected ?string $content = null;
+    protected ?string $method = null;
+    protected string $template = 'blank';
+    protected string $title = 'Section title or question';
+    protected bool $hideTitle = false;
+    
+    // Setup
+    public function __construct(string $title)
+    {
+        $this->setTitle($title);
+    }
+
+    public static function create(string $title): self
+    {
+        return new self($title);
+    }
+    
+    // Setters
+    public function addBreadcrumb(string $label, string $route): self
+    {
+        $this->back = null;
+        $this->breadcrumbs[] = [$label => $route]; 
+        
+        return $this;
+    }
+    
+    public function hideTitle(): self
+    {
+        $this->hideTitle = true;
+        return $this;
+    }
+
+    public function setAction(string $route = null): self
+    {
+        $this->action = $route;
+        return $this;
+    }
+    
+    public function setBack(string $route = null): self
+    {
+        $this->back = $route;
+        $this->breadcrumbs = null;
+
+        return $this;
+    }
+    
+    public function setButtonLabel(string $label = null): self
+    {
+        $this->buttonLabel = $label;
+        return $this;
+    }
+    
+    public function setButtonType(string $type): self
+    {
+        $this->buttonType = in_array($type, self::BUTTON_TYPES, true) === true
+            ? $type
+            : self::NORMAL_BUTTON;
+        
+        return $this;
+    }
+    
+    public function setCaption(string $caption = null): self
+    {
+        $this->caption = $caption;
+        return $this;
+    }
+    
+    public function setContent(string $content = null): self
+    {
+        $this->content = $content;
+        return $this;
+    }
+    
+    public function setMethod(string $method = null): self
+    {
+        $this->method = $method;
+        return $this;
+    }
+    
+    public function setTemplate(string $template): self
+    {
+        $this->template = $template;
+        return $this;
+    }
+    
+    public function setTitle(string $title): self
+    {
+        $this->title = $title;
+        return $this;
+    }
+
+    public function showTitle(): self
+    {
+        $this->hideTitle = false;
+        return $this;
+    }
+    
+    // Getters
+    public function toArray(): array
+    {
+        return [
+            'back' => $this->back,
+            'breadcrumbs' => $this->breadcrumbs,
+            'buttonLabel' => $this->buttonLabel,
+            'buttonType' => $this->buttonType,
+            'caption' => $this->caption,
+            'content' => $this->content,
+            'hideTitle' => $this->hideTitle,
+            'template' => $this->template,
+            'title' => $this->title,
+        ];
+    }
+    
+    public function toView(): View
+    {
+        return view("templates.{$this->template}", $this->toArray());
+    }
 }

--- a/src/app/Pages/Page.php
+++ b/src/app/Pages/Page.php
@@ -124,6 +124,7 @@ class Page
     public function toArray(): array
     {
         return [
+            'action' => $this->action,
             'back' => $this->back,
             'breadcrumbs' => $this->breadcrumbs,
             'buttonLabel' => $this->buttonLabel,
@@ -131,6 +132,7 @@ class Page
             'caption' => $this->caption,
             'content' => $this->content,
             'hideTitle' => $this->hideTitle,
+            'method' => $this->method,
             'template' => $this->template,
             'title' => $this->title,
         ];
@@ -138,6 +140,6 @@ class Page
     
     public function toView(): View
     {
-        return view("templates.{$this->template}", $this->toArray());
+        return view("templates::{$this->template}", $this->toArray());
     }
 }

--- a/src/resources/views/components/button.blade.php
+++ b/src/resources/views/components/button.blade.php
@@ -4,6 +4,7 @@
     'preventDoubleClick' => false,
     'secondary' => false,
     'start' => false,
+    'type' => null,
     'warning' => false,
 ])
 
@@ -14,15 +15,15 @@
         $classes .= ' govuk-button--disabled';
     }
 
-    if ($secondary === true) {
+    if ($secondary === true || $type === 'secondary') {
         $classes .= ' govuk-button--secondary';
     }
 
-    if ($start === true) {
+    if ($start === true || $type === 'start') {
         $classes .= ' govuk-button--start';
     }
 
-    if ($warning === true) {
+    if ($warning === true || $type === 'warning') {
         $classes .= ' govuk-button--warning';
     }
 

--- a/src/resources/views/layout/page.blade.php
+++ b/src/resources/views/layout/page.blade.php
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template ">
-    @include('layout.head')
+    @include('govuk::layout.head')
 
     <body class="govuk-template__body">
         <script>
@@ -9,22 +9,22 @@
 
         <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 
-        @include('layout.header')
+        @include('govuk::layout.header')
 
         <div class="govuk-width-container ">
-            @include('parts.testing')
-            @include('parts.impersonation')
+            @include('govuk::parts.testing')
+            @include('govuk::parts.impersonation')
             @yield('heading')
-            @include('parts.breadcrumbs')
-            @include('parts.back')
+            @include('govuk::parts.breadcrumbs')
+            @include('govuk::parts.back')
             @include('flash::message')
-            @include('parts.errors')
+            @include('govuk::parts.errors')
 
             <main class="govuk-main-wrapper " id="main-content" role="main">
                 <div class="govuk-grid-row">
                     <div class="govuk-grid-column-two-thirds">
-                        @include('parts.caption')
-                        @include('parts.title')
+                        @include('govuk::parts.caption')
+                        @include('govuk::parts.title')
                         @yield('content')
                     </div>
 
@@ -35,7 +35,7 @@
             </main>
         </div>
 
-        @include('layout.footer')
-        @include('layout.foot')
+        @include('govuk::layout.footer')
+        @include('govuk::layout.foot')
     </body>
 </html>

--- a/src/resources/views/parts/title.blade.php
+++ b/src/resources/views/parts/title.blade.php
@@ -1,4 +1,3 @@
-@isset($hideTitle)
-@else
+@if($hideTitle !== true)
     <x-govuk::h1>{{ $title }}</x-govuk::h1>
 @endisset

--- a/src/resources/views/templates/confirm.blade.php
+++ b/src/resources/views/templates/confirm.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.govuk')
+@extends('govuk::layout.page')
 
 @section('content')
     @if($content !== null)
@@ -9,7 +9,7 @@
 
     <x-govuk::form action="{{ $action }}" method="{{ $method }}">
         <x-govuk::button-group>
-            <x-govuk::button {{ $buttonType }}>
+            <x-govuk::button type="$buttonType">
                 {{ $buttonLabel }}
             </x-govuk::button>
 

--- a/src/resources/views/templates/confirm.blade.php
+++ b/src/resources/views/templates/confirm.blade.php
@@ -9,7 +9,7 @@
 
     <x-govuk::form action="{{ $action }}" method="{{ $method }}">
         <x-govuk::button-group>
-            <x-govuk::button type="$buttonType">
+            <x-govuk::button :type="$buttonType">
                 {{ $buttonLabel }}
             </x-govuk::button>
 

--- a/src/resources/views/templates/confirm.blade.php
+++ b/src/resources/views/templates/confirm.blade.php
@@ -1,0 +1,19 @@
+@extends('layout.govuk')
+
+@section('content')
+    @if($content !== null)
+        @include($content)
+    @endif
+
+    <x-govuk::section-break />
+
+    <x-govuk::form action="{{ $action }}" method="{{ $method }}">
+        <x-govuk::button-group>
+            <x-govuk::button {{ $buttonType }}>
+                {{ $buttonLabel }}
+            </x-govuk::button>
+
+            <x-govuk::a href="{{ $back }}">Cancel and back</x-govuk::a>
+        </x-govuk::button-group>
+    </x-govuk::form>
+@endsection

--- a/src/resources/views/templates/template.blade.php
+++ b/src/resources/views/templates/template.blade.php
@@ -1,4 +1,4 @@
-@extends('layout.govuk')
+@extends('layout.page')
 
 @php
     // Each of these parameters are optional - use them where needed


### PR DESCRIPTION
You can now create a confirmation page by calling the `GovukPage` helper, and passing in the required parameters.

This will slowly be rolled out to other page types.