### PR TITLE
Added handling for Laravel dot syntax on old and error values.

### DIFF
--- a/src/app/Helpers/GovukQuestion.php
+++ b/src/app/Helpers/GovukQuestion.php
@@ -87,4 +87,40 @@ class GovukQuestion
             $id
         );
     }
+
+    public static function dotsToBrackets(string $name): string
+    {
+        if (str_contains($name, '.') === false) {
+            return $name;
+        }
+
+        $pieces = explode('.', $name);
+        $name = '';
+
+        foreach ($pieces as $piece) {
+            $name .= $name === ''
+                ? $piece
+                : "[$piece]";
+        }
+
+        return $name;
+    }
+
+    public static function bracketsToDots(string $name): string
+    {
+        if (str_contains($name, '[') === false || str_contains($name, ']') === false) {
+            return $name;
+        }
+
+        $pieces = explode('[', $name);
+        $name = '';
+
+        foreach ($pieces as $piece) {
+            $name .= $name === ''
+                ? $piece
+                : '.' . rtrim($piece, ']');
+        }
+
+        return $name;
+    }
 }

--- a/src/app/Questions/Question.php
+++ b/src/app/Questions/Question.php
@@ -90,9 +90,15 @@ class Question
         return $this;
     }
 
-    public function hint(string $hint): self
+    public function hint(string $hint = null): self
     {
         $this->hint = $hint;
+        return $this;
+    }
+    
+    public function id(string $id): self
+    {
+        $this->id = $id;
         return $this;
     }
 

--- a/src/resources/views/components/checkboxes.blade.php
+++ b/src/resources/views/components/checkboxes.blade.php
@@ -21,6 +21,7 @@
 
     $ariaDescription = '';
     $inputClasses = 'govuk-checkboxes';
+    $oldName = \AnthonyEdmonds\GovukLaravel\Helpers\GovukQuestion::bracketsToDots($name);
 
     if ($isSmall === true) {
         $inputClasses .= ' govuk-checkboxes--small';
@@ -30,7 +31,7 @@
         $inputClasses .= ' govuk-checkboxes--conditional';
     }
 
-    $value = old($name, $value);
+    $value = old($oldName, $value);
     if (is_array($value) === false) {
         $value = $value !== null
             ? [$value]

--- a/src/resources/views/components/date-input.blade.php
+++ b/src/resources/views/components/date-input.blade.php
@@ -37,6 +37,8 @@
             $autocompleteMonth = $autocomplete;
             $autocompleteYear = $autocomplete;
     }
+    
+    // TODO Old values
 @endphp
 
 <x-govuk::form-group :name="$name">

--- a/src/resources/views/components/error-summary.blade.php
+++ b/src/resources/views/components/error-summary.blade.php
@@ -17,7 +17,7 @@
         <ul class="govuk-list govuk-error-summary__list">
             @foreach($messages as $id => $message)
                 <li>
-                    <a href="#{{ $id }}">{{ $message }}</a>
+                    <a href="#{{ \AnthonyEdmonds\GovukLaravel\Helpers\GovukQuestion::dotsToBrackets($id) }}">{{ $message }}</a>
                 </li>
             @endforeach
         </ul>

--- a/src/resources/views/components/form-group.blade.php
+++ b/src/resources/views/components/form-group.blade.php
@@ -5,7 +5,7 @@
 @php
     $groupClasses = 'govuk-form-group';
 
-    if ($errors->has($name) === true) {
+    if ($errors->has(\AnthonyEdmonds\GovukLaravel\Helpers\GovukQuestion::bracketsToDots($name)) === true) {
         $groupClasses .= ' govuk-form-group--error';
     }
 @endphp

--- a/src/resources/views/components/form-group/error.blade.php
+++ b/src/resources/views/components/form-group/error.blade.php
@@ -3,7 +3,7 @@
     'name',
 ])
 
-@error($name)
+@error(\AnthonyEdmonds\GovukLaravel\Helpers\GovukQuestion::bracketsToDots($name))
     <span class="govuk-error-message" id="{{ $id }}-error" >
         <span class="govuk-visually-hidden">Error: </span>{{ $message }}
     </span>

--- a/src/resources/views/components/radios.blade.php
+++ b/src/resources/views/components/radios.blade.php
@@ -22,6 +22,7 @@
 
     $ariaDescription = '';
     $inputClasses = 'govuk-radios';
+    $oldName = \AnthonyEdmonds\GovukLaravel\Helpers\GovukQuestion::bracketsToDots($name);
 
     if ($isSmall === true) {
         $inputClasses .= ' govuk-radios--small';
@@ -33,7 +34,7 @@
         $inputClasses .= ' govuk-radios--inline';
     }
 
-    $value = old($name, $value);
+    $value = old($oldName, $value);
 @endphp
 
 <x-govuk::form-group :name="$name">

--- a/src/resources/views/components/search-bar.blade.php
+++ b/src/resources/views/components/search-bar.blade.php
@@ -31,7 +31,7 @@
                 name="{{ $name }}"
                 spellcheck="false"
                 type="search"
-                value="{{ old($name, $value) }}"
+                value="{{ old(\AnthonyEdmonds\GovukLaravel\Helpers\GovukQuestion::bracketsToDots($name), $value) }}"
             />
 
             <x-govuk::button aria-label="Search">

--- a/src/resources/views/components/select.blade.php
+++ b/src/resources/views/components/select.blade.php
@@ -13,17 +13,18 @@
 @php
     $ariaDescription = '';
     $inputClasses = 'govuk-select';
+    $oldName = \AnthonyEdmonds\GovukLaravel\Helpers\GovukQuestion::bracketsToDots($name);
 
     if ($hint !== null) {
         $ariaDescription .= "{$id}-hint";
     }
 
-    if ($errors->has($name) === true) {
+    if ($errors->has($oldName) === true) {
         $ariaDescription .= " {$id}-error";
         $inputClasses .= ' govuk-select--error';
     }
 
-    $value = old($name, $value);
+    $value = old($oldName, $value);
 @endphp
 
 <x-govuk::form-group :name="$name">

--- a/src/resources/views/components/text-input.blade.php
+++ b/src/resources/views/components/text-input.blade.php
@@ -22,6 +22,7 @@
 @php
     $ariaDescription = '';
     $inputClasses = 'govuk-input';
+    $oldName = \AnthonyEdmonds\GovukLaravel\Helpers\GovukQuestion::bracketsToDots($name);
 
     if ($hint !== null) {
         $ariaDescription .= "{$id}-hint";
@@ -35,7 +36,7 @@
         $inputClasses .= ' govuk-js-character-count';
     }
 
-    if ($errors->has($name) === true) {
+    if ($errors->has($oldName) === true) {
         $ariaDescription .= " {$id}-error";
         $inputClasses .= ' govuk-input--error';
     }
@@ -71,7 +72,7 @@
                 placeholder="{{ $placeholder }}"
                 spellcheck="{{ $spellcheck == true ? 'true' : 'false' }}"
                 type="{{ $type }}"
-                value="{{ old($name, $value) }}"
+                value="{{ old($oldName, $value) }}"
             />
             
             @if($suffix !== null)

--- a/src/resources/views/components/textarea.blade.php
+++ b/src/resources/views/components/textarea.blade.php
@@ -18,6 +18,7 @@
 @php
     $ariaDescription = '';
     $inputClasses = 'govuk-textarea';
+    $oldName = \AnthonyEdmonds\GovukLaravel\Helpers\GovukQuestion::bracketsToDots($name);
 
     if ($hint !== null) {
         $ariaDescription .= "{$id}-hint";
@@ -27,7 +28,7 @@
         $inputClasses .= ' govuk-js-character-count';
     }
 
-    if ($errors->has($name) === true) {
+    if ($errors->has($oldName) === true) {
         $ariaDescription .= " {$id}-error";
         $inputClasses .= ' govuk-textarea--error';
     }
@@ -58,7 +59,7 @@
             placeholder="{{ $placeholder }}"
             rows="{{ $rows }}"
             spellcheck="{{ $spellcheck == true ? 'true' : 'false' }}"
-        >{{ old($name, $value) }}</textarea>
+        >{{ old($oldName, $value) }}</textarea>
 
         <x-govuk::form-group.counter :id="$id" />
     </x-govuk::form-group>


### PR DESCRIPTION
Added handling for Laravel array validation dot syntax. Quite why we can't just have dots OR brackets, is beyond me