### PR TITLE
Hotfix/first or fail

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,4 +6,3 @@ parameters:
   ignoreErrors:
     - '#Call to an undefined method#'
     - '#Access to an undefined property#'
-    - '#Call to an undefined static method#'

--- a/src/app/Forms/Form.php
+++ b/src/app/Forms/Form.php
@@ -251,7 +251,7 @@ abstract class Form
     // Subject
     public function loadSubjectFromDatabase(int|string $subjectKey): Model
     {
-        return $this->makeNewSubject()::findOrFail($subjectKey);
+        return $this->makeNewSubject()::firstOrFail($subjectKey);
     }
 
     protected function getSubjectFromSession(): Model

--- a/src/app/Forms/Form.php
+++ b/src/app/Forms/Form.php
@@ -251,7 +251,11 @@ abstract class Form
     // Subject
     public function loadSubjectFromDatabase(int|string $subjectKey): Model
     {
-        return $this->makeNewSubject()::firstOrFail($subjectKey);
+        $subject = $this->makeNewSubject();
+
+        return $subject->newQuery()
+            ->where($subject->getRouteKeyName(), '=', $subjectKey)
+            ->firstOrFail();
     }
 
     protected function getSubjectFromSession(): Model

--- a/tests/Unit/Forms/Form/LoadSubjectFromDatabaseTest.php
+++ b/tests/Unit/Forms/Form/LoadSubjectFromDatabaseTest.php
@@ -8,22 +8,25 @@ use AnthonyEdmonds\GovukLaravel\Tests\TestCase;
 
 class LoadSubjectFromDatabaseTest extends TestCase
 {
+    protected FormModel $subject;
+
+    protected TestForm $form;
+
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->useDatabase();
+
+        $this->subject = FormModel::factory()->create();
+        $this->form = new TestForm();
     }
 
     public function testLoadsSubjectFromDatabase(): void
     {
-        $subject = FormModel::factory()->create();
-
-        $form = new TestForm();
-
         $this->assertEquals(
-            $subject->id,
-            $form->loadSubjectFromDatabase($subject->id)->id,
+            $this->subject->id,
+            $this->form->loadSubjectFromDatabase($this->subject->id)->id,
         );
     }
 }


### PR DESCRIPTION
Turns out that findOrFail only works on the primary key, which is usually ID.