### PR TITLE
Hotfix/subject request

### DIFF
--- a/src/app/Forms/Question.php
+++ b/src/app/Forms/Question.php
@@ -31,6 +31,9 @@ abstract class Question
 
     public function validate(Request $request, Model $subject): void
     {
+        request()->mergeIfMissing([
+            'subject' => $subject,
+        ]);
         app($this->getFormRequest()::class);
     }
 

--- a/src/app/Forms/Question.php
+++ b/src/app/Forms/Question.php
@@ -31,7 +31,7 @@ abstract class Question
 
     public function validate(Request $request, Model $subject): void
     {
-        request()->mergeIfMissing([
+        request()->merge([
             'subject' => $subject,
         ]);
         app($this->getFormRequest()::class);


### PR DESCRIPTION
When I moved validation to use the Laravel app container, the subject got removed again.

This approach does mean that anyone using $subject as their form key will need to be careful.