### PR TITLE
Bugfix/date zero

### DIFF
--- a/src/app/Rules/Dates/DateRule.php
+++ b/src/app/Rules/Dates/DateRule.php
@@ -36,19 +36,19 @@ abstract class DateRule implements ValidationRule, DataAwareRule
         $month = $this->data["$attribute-month"];
         $year = $this->data["$attribute-year"];
 
-        if ($this->validateInteger($attribute, $day) === false) {
+        if ($this->validateDigitsBetween($attribute, $day, [1, 2]) === false) {
             $fail(':attribute day must be a number');
 
             return;
         }
 
-        if ($this->validateInteger($attribute, $month) === false) {
+        if ($this->validateDigitsBetween($attribute, $month, [1, 2]) === false) {
             $fail(':attribute month must be a number');
 
             return;
         }
 
-        if ($this->validateInteger($attribute, $year) === false) {
+        if ($this->validateDigitsBetween($attribute, $year, [1, 4]) === false) {
             $fail(':attribute year must be a number');
 
             return;

--- a/tests/Unit/Rules/Dates/DateRuleTestCase.php
+++ b/tests/Unit/Rules/Dates/DateRuleTestCase.php
@@ -50,13 +50,6 @@ class DateRuleTestCase extends TestCase
         $this->assertRuleFails($this->rule, self::DATE_FIELD, self::VALUE, ':attribute year must be a number');
     }
 
-    public function testPassesWhenLeadingZero(): void
-    {
-        $this->setRuleData('08', '08', '0202');
-
-        $this->assertRulePasses($this->rule, self::DATE_FIELD, self::VALUE);
-    }
-
     protected function setRuleData(
         int|string $day,
         int|string $month,

--- a/tests/Unit/Rules/Dates/DateRuleTestCase.php
+++ b/tests/Unit/Rules/Dates/DateRuleTestCase.php
@@ -50,6 +50,13 @@ class DateRuleTestCase extends TestCase
         $this->assertRuleFails($this->rule, self::DATE_FIELD, self::VALUE, ':attribute year must be a number');
     }
 
+    public function testPassesWhenLeadingZero(): void
+    {
+        $this->setRuleData('08', '08', '0202');
+
+        $this->assertRulePasses($this->rule, self::DATE_FIELD, self::VALUE);
+    }
+
     protected function setRuleData(
         int|string $day,
         int|string $month,


### PR DESCRIPTION
Allowed digits, rather than parsing int. Apparently Laravel can't tell `08` and `8`.

Initially trimmed leading zeroes with `ltrim`, but this seemed more robust for checking that it is both a number and within a certain length.